### PR TITLE
Added a change in timezone for the base image to Europe/Copenhagen

### DIFF
--- a/images/base/context/Dockerfile
+++ b/images/base/context/Dockerfile
@@ -16,3 +16,8 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 
 # Add /srv/java on PATH variable
 ENV PATH ${PATH}:${JAVA_HOME}/bin:/srv/java
+
+# Secure the right timezone is applied
+RUN echo "Europe/Copenhagen" >/etc/timezone && \
+ln -sf /usr/share/zoneinfo/Europe/Copenhagen /etc/localtime && \
+dpkg-reconfigure -f noninteractive tzdata


### PR DESCRIPTION
Resolution to #74.

Timezone is set to UTC in the normal container creation, giving wrong timestamps in eg. Bitbucket.

There are possibly different solutions to this problem:

- Setting it in the docker file
- Mounting the host timezone

I chose the first one, since i have no idea about the implications about the second in combination with docker-machine etc.
@hoeghh and @bicschneider can i get a sanity check on this one?
 